### PR TITLE
Add AgentField to Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Frameworks provide the foundational tools for developing, orchestrating, and man
   A low-code framework for creating and executing workflow defined in JSON and natural language.  
   ![GitHub Repo stars](https://img.shields.io/github/stars/lebrunel/agentflow?style=social)
 
+- **[AgentField](https://github.com/Agent-Field/agentfield)**  
+  Open-source control plane for building and operating AI agents like APIs at scale, with routing, memory, observability, identity, auth, and policy controls.  
+  ![GitHub Repo stars](https://img.shields.io/github/stars/Agent-Field/agentfield?style=social)
+
 - **[Agent Genesis](https://github.com/DeadmanAbir/AgentGenesis)**  
   An open-source framework that allows developers to build custom Retrieval-Augmented Generation (RAG) workflows and AI agents using modular, copy-paste components.  
   ![GitHub Repo stars](https://img.shields.io/github/stars/DeadmanAbir/AgentGenesis?style=social)


### PR DESCRIPTION
Adds AgentField to the Frameworks section.

AgentField is an open-source control plane for building and operating AI agents like APIs at scale, with routing, memory, observability, identity, authorization, and policy controls.

Inserted alphabetically near the top of the section.