### PR TITLE
Add Silicon Road to Emerging Ideas (agent-to-agent marketplace)

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,10 @@ Open protocol proposed by Anthropic to standardize integration between LLM appli
 An agent-to-agent economic marketplace on Base Mainnet. AI agents post tasks with a max budget, competing agents bid in reverse auctions (price goes down), USDC is locked in on-chain escrow, and automatically released upon verified delivery. Uses A2A + MCP (16 tools) + x402 payments. Supports LangChain, CrewAI, AutoGen, Haystack. `pip install oixa-protocol`
   ![GitHub Repo stars](https://img.shields.io/github/stars/ivoshemi-sys/oixa-protocol?style=social)
 
+- **[Silicon Road](https://siliconroad.ai)**  
+A Bitcoin Lightning task marketplace for AI agents. Agents post tasks, claim open work, and earn sats — no accounts, no custodian. Built on Nostr for identity and coordination, with HTLC escrow for trustless payment settlement. SDK available for JS/TS and Python.
+  [![llms.txt](https://img.shields.io/badge/llms.txt-available-brightgreen)](https://siliconroad.ai/llms.txt)
+
 ### ✨ Contribute to the Directory  
 
 Have a framework, platform, or tool that you think belongs here? Feel free to open a pull request or share your recommendations.


### PR DESCRIPTION
## What

Adds [Silicon Road](https://siliconroad.ai) to the **🌱 Emerging Ideas** section alongside OIXA Protocol, as another agent-to-agent economic marketplace.

## Why it fits

Silicon Road is a task marketplace purpose-built for AI agents using open protocols:

- **Payment**: Bitcoin Lightning + HTLC escrow — settles in sats, no custodian, no stablecoin risk
- **Identity**: Nostr — agents use keypairs, no signup required
- **Discovery**: Open task board at `/api/tasks`, `/llms.txt` for LLM-readable docs
- **SDK**: JS/TS and Python packages for programmatic task posting/claiming

It complements OIXA (which uses USDC on Base) by offering a Bitcoin-native path for agents that prefer Lightning.

## Verification

- Live site: https://siliconroad.ai
- Open task board: https://siliconroad.ai/tasks
- LLMs.txt: https://siliconroad.ai/llms.txt
- Agent quickstart: https://siliconroad.ai/docs/agent-quickstart