### PR TITLE
Add Dakera to Frameworks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Frameworks provide the foundational tools for developing, orchestrating, and man
   A low-code framework for creating and executing workflow defined in JSON and natural language.  
   ![GitHub Repo stars](https://img.shields.io/github/stars/lebrunel/agentflow?style=social)
 
-- **[Dakera](https://github.com/Dakera-AI/dakera)**  
+- **[Dakera](https://github.com/dakera-ai/dakera-deploy-deploy)**  
   Production-ready persistent memory layer for AI agents, providing hybrid BM25 + vector retrieval, temporal reasoning, and importance-weighted decay. Integrates with LangChain, LlamaIndex, CrewAI, and AutoGen.  
-  ![GitHub Repo stars](https://img.shields.io/github/stars/Dakera-AI/dakera?style=social)
+  ![GitHub Repo stars](https://img.shields.io/github/stars/dakera-ai/dakera-deploy-deploy?style=social)
 
 - **[AgentField](https://github.com/Agent-Field/agentfield)**  
   Open-source control plane for building and operating AI agents like APIs at scale, with routing, memory, observability, identity, auth, and policy controls.  

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Frameworks provide the foundational tools for developing, orchestrating, and man
   A low-code framework for creating and executing workflow defined in JSON and natural language.  
   ![GitHub Repo stars](https://img.shields.io/github/stars/lebrunel/agentflow?style=social)
 
+- **[Dakera](https://github.com/Dakera-AI/dakera)**  
+  Production-ready persistent memory layer for AI agents, providing hybrid BM25 + vector retrieval, temporal reasoning, and importance-weighted decay. Integrates with LangChain, LlamaIndex, CrewAI, and AutoGen.  
+  ![GitHub Repo stars](https://img.shields.io/github/stars/Dakera-AI/dakera?style=social)
+
 - **[AgentField](https://github.com/Agent-Field/agentfield)**  
   Open-source control plane for building and operating AI agents like APIs at scale, with routing, memory, observability, identity, auth, and policy controls.  
   ![GitHub Repo stars](https://img.shields.io/github/stars/Agent-Field/agentfield?style=social)
@@ -199,4 +203,3 @@ Have a framework, platform, or tool that you think belongs here? Feel free to op
 ---
 
 🌟 *Help us grow this directory by starring the repositories and sharing this page! Together, we can accelerate innovation in the AI agent space.* 🌟
-

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Frameworks provide the foundational tools for developing, orchestrating, and man
   A low-code framework for creating and executing workflow defined in JSON and natural language.  
   ![GitHub Repo stars](https://img.shields.io/github/stars/lebrunel/agentflow?style=social)
 
-- **[Dakera](https://github.com/dakera-ai/dakera-deploy-deploy)**  
+- **[Dakera](https://github.com/dakera-ai/dakera-deploy)**  
   Production-ready persistent memory layer for AI agents, providing hybrid BM25 + vector retrieval, temporal reasoning, and importance-weighted decay. Integrates with LangChain, LlamaIndex, CrewAI, and AutoGen.  
-  ![GitHub Repo stars](https://img.shields.io/github/stars/dakera-ai/dakera-deploy-deploy?style=social)
+  ![GitHub Repo stars](https://img.shields.io/github/stars/dakera-ai/dakera-deploy?style=social)
 
 - **[AgentField](https://github.com/Agent-Field/agentfield)**  
   Open-source control plane for building and operating AI agents like APIs at scale, with routing, memory, observability, identity, auth, and policy controls.  


### PR DESCRIPTION
Adds [Dakera](https://github.com/Dakera-AI/dakera) to the 🛠 Frameworks section.

Dakera is a production-ready persistent memory layer for AI agents. It handles the memory/persistence concern that agent frameworks leave to developers — providing:

- **Hybrid retrieval**: BM25 + vector search so agents find the right memory from any query style
- **Temporal reasoning**: time-aware memory scoring and decay
- **Importance weighting**: critical memories persist; ephemeral ones decay
- **Multi-tenant**: namespace isolation for production deployments

Integrates directly with LangChain, LlamaIndex, CrewAI, and AutoGen via official packages (`pip install langchain-dakera`).

- GitHub: https://github.com/Dakera-AI/dakera
- Docs: https://docs.dakera.ai