### PR TITLE
Add Bernstein to Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Frameworks provide the foundational tools for developing, orchestrating, and man
   An open-source toolkit designed to create scalable agent-based workflows with various AI models.  
   ![GitHub Repo stars](https://img.shields.io/github/stars/i-am-bee/bee-agent-framework?style=social)
 
+- **[Bernstein](https://github.com/sipyourdrink-ltd/bernstein)**  
+  Python orchestrator that drives 40+ CLI coding agents (Claude Code, Codex, Gemini CLI, Cursor, Aider) in parallel git worktrees. One LLM plan call up front; then deterministic scheduling, quality gates, and an HMAC-chained audit log. Apache-2.0.  
+  ![GitHub Repo stars](https://img.shields.io/github/stars/sipyourdrink-ltd/bernstein?style=social)
+
 - **[CAMEL](https://github.com/camel-ai/camel)**  
   Emerging from a research community exploring the “scaling laws” of AI agents. Designed as a sandbox to study how collaborative AI systems perform and evolve as the number of agents grows.
   ![GitHub Repo stars](https://img.shields.io/github/stars/camel-ai/camel?style=social)

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Frameworks provide the foundational tools for developing, orchestrating, and man
   ![GitHub Repo stars](https://img.shields.io/github/stars/i-am-bee/bee-agent-framework?style=social)
 
 - **[Bernstein](https://github.com/sipyourdrink-ltd/bernstein)**  
-  Python orchestrator that drives 40+ CLI coding agents (Claude Code, Codex, Gemini CLI, Cursor, Aider) in parallel git worktrees. One LLM plan call up front; then deterministic scheduling, quality gates, and an HMAC-chained audit log. Apache-2.0.  
+  Open-source governance layer for AI agents, with an HMAC-chained audit log over every run. Drives 40+ agent CLIs (Claude Code, Codex, Gemini CLI, Cursor, Aider) in parallel git worktrees. One LLM plan call up front; then deterministic scheduling and quality gates. Apache-2.0.  
   ![GitHub Repo stars](https://img.shields.io/github/stars/sipyourdrink-ltd/bernstein?style=social)
 
 - **[CAMEL](https://github.com/camel-ai/camel)**  


### PR DESCRIPTION
Adds Bernstein to the Frameworks section, alphabetically between Bee Agent Framework and CAMEL.

- Repo: https://github.com/sipyourdrink-ltd/bernstein
- License: Apache-2.0
- 350 stars, on PyPI as \`bernstein\`.
- Open-source governance layer for AI agents, with an HMAC-chained audit log over every run. Drives 40+ agent CLIs (Claude Code, Codex, Gemini CLI, Cursor, Aider). One LLM plan call up front; then deterministic scheduling, parallel git worktrees, and quality gates.

Maintainer disclosure: I am the maintainer.
