### PR TITLE
feat: add TWZRD Agent Intel — agent trust scoring for observability stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,15 @@ Frameworks provide the foundational tools for developing, orchestrating, and man
   Upsonic is a reliable agent framework supporting MCP, offering trusted agent workflows with verification layers.
   ![GitHub Repo stars](https://img.shields.io/github/stars/upsonic/upsonic?style=social)
 
+<a id="security-and-trust"></a>
+## 🔐 Security and Trust
+
+Tools for agent identity verification, trust scoring, and behavioral attestation in multi-agent workflows.
+
+- **[TWZRD Agent Intel](https://intel.twzrd.xyz)**  
+  On-chain behavioral trust scoring for AI agents on Solana. MCP-accessible: `score_agent(wallet)` and `preflight_check(wallet)` (free); `get_trust_receipt(wallet)` (paid via x402 micropayment). Provides verifiable trust signals for agent-to-agent interactions and x402 payment gating.  
+  Free MCP config: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
+
 <a id="observability-and-tracing"></a>
 ## 🔍 Observability and Tracing
 


### PR DESCRIPTION
## Summary

Adds TWZRD Agent Intel to a new **Security and Trust** section.

### What

[TWZRD Agent Intel](https://intel.twzrd.xyz) provides on-chain behavioral trust scoring for AI agents on Solana. It's MCP-accessible and complements observability tools by adding trust signals to multi-agent workflows:

- **`score_agent(wallet)`** — trust score (0-100) derived from on-chain behavioral history
- **`preflight_check(wallet)`** — fast gate before granting resources or access
- **`get_trust_receipt(wallet)`** — signed, verifiable trust receipt (paid via x402 micropayment)

Free MCP config: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`

### Why a Security & Trust section

The current list covers frameworks, observability, and emerging ideas — but lacks coverage of agent trust and behavioral attestation. As multi-agent workflows mature, trust verification becomes as important as tracing. This new section captures that gap.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)