### PR TITLE
Add Atomic Agent to Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Frameworks provide the foundational tools for developing, orchestrating, and man
   A versatile, open-source framework created by BrainBlend AI for developing multi-agent systems and AI applications.  
   ![GitHub Repo stars](https://img.shields.io/github/stars/BrainBlend-AI/atomic-agents?style=social)
 
+- **[Atomic Agent (AtomicBot)](https://github.com/AtomicBot-ai/atomic-agent)**  
+  A local-first CLI and TUI coding assistant that runs open-weight models entirely on your machine through a llama.cpp fork, with no account or API key required. Ships 56 built-in tools (browser, filesystem, git, memory, vision), MCP support, and a five-layer local memory system across macOS, Linux, and Windows. Currently a developer preview, so APIs and commands are still moving.  
+  ![GitHub Repo stars](https://img.shields.io/github/stars/AtomicBot-ai/atomic-agent?style=social)
+
 - **[AutoGPT](https://github.com/Significant-Gravitas/AutoGPT)**  
 
 - **[GolemCore Bot](https://github.com/alexk-dev/golemcore-bot)**  


### PR DESCRIPTION
Hi! I'm the CPO of Atomic Agent, and thanks for putting this directory together. Our team would be thrilled to be included.

Adding **Atomic Agent** to the Frameworks section: a local-first CLI and TUI coding assistant that runs open-weight models entirely on your machine through a llama.cpp fork, with no account or API key required to install or run it. It ships 56 built-in tools (browser, filesystem, git, memory, vision), MCP support, and a five-layer local memory system, and it runs on macOS, Linux, and Windows.

One note in the interest of being upfront: the project is currently a developer preview, so APIs, commands, and config are still moving. I mentioned that in the entry itself rather than leaving it out. The repo is MIT licensed, actively maintained, and at ~2k stars.

There is already an entry called "Atomic Agent" (BrainBlend-AI/atomic-agents), which is a different project. To avoid confusion I listed ours as "Atomic Agent (AtomicBot)". Happy to rename it to whatever you prefer.

Placed alphabetically in Frameworks, right after the existing Atomic Agent entry and before AutoGPT. The row follows the existing format: bold linked name, description, and the star badge.

A few more links if useful:
- Site: https://atomicagent.io
- Docs: https://atomicagent.io/docs
- Install: `curl -fsSL https://atomicagent.io/install | sh`
- Discord: https://discord.gg/Us7qXtDGw
- X: https://x.com/atomicagent_io

Thanks for taking a look, and no worries at all if it isn't the right fit.
