### PR TITLE
Add Agent QA testing and QA section

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ By [Deep Insight Labs](https://www.deepinsightlabs.ai)
 
 1. [Frameworks](#frameworks)
 2. [Observability and Tracing](#observability-and-tracing)
-3. [Platforms](#platforms) *(Coming Soon)*
-4. [Emerging Ideas](#emerging-ideas)
+3. [Testing and QA](#testing-and-qa)
+4. [Platforms](#platforms) *(Coming Soon)*
+5. [Emerging Ideas](#emerging-ideas)
 
 <a id="frameworks"></a>
 ## 🛠 Frameworks
@@ -169,6 +170,15 @@ This section will include tools and resources to monitor, debug, and analyze AI 
   Open-source observability, tracing, and evaluation platform for LLM applications and agent workflows.  
   ![GitHub Repo stars](https://img.shields.io/github/stars/comet-ml/opik?style=social)
 
+<a id="testing-and-qa"></a>
+## ✅ Testing and QA
+
+This section covers tools that let agents and teams exercise applications and validate user workflows.
+
+- **[Agent QA](https://github.com/vostride/agent-qa)**
+  Agentic QA CLI and MCP server for natural-language web and mobile tests using configured model and browser or device providers.
+  ![GitHub Repo stars](https://img.shields.io/github/stars/vostride/agent-qa?style=social)
+
 <a id="platforms"></a>
 ## 🚀 Platforms *(Coming Soon)*
 
@@ -199,4 +209,3 @@ Have a framework, platform, or tool that you think belongs here? Feel free to op
 ---
 
 🌟 *Help us grow this directory by starring the repositories and sharing this page! Together, we can accelerate innovation in the AI agent space.* 🌟
-


### PR DESCRIPTION
## Summary

- add a Testing and QA section to the directory and its table of contents
- list Agent QA as an application-QA CLI and MCP server for natural-language web/mobile tests
- describe the configured model and browser/device-provider boundary without classifying the project as open source
- normalize the README's pre-existing extra final blank line

## Validation

- the canonical repository and GitHub stars badge links return HTTP 200
- the focused README change passes `git diff --check`

## Disclosure

I am affiliated with Agent QA and Vostride.

Agent QA's current release is source-available under FSL-1.1-ALv2, not OSI-approved open source; each release converts to Apache-2.0 two years after publication.

Agent QA itself can be used without a package fee, but separate model, browser, or device providers may charge for their services.
